### PR TITLE
4-get-api-articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,7 @@ node query.js
     - using previous model and conttollers
     - client -> controller -> model(sql) -> db.query(quesrtStr) send to PostgreSQL -> SQL query get data + count comments + sortby -> result.rows -> go back to controller > client
     - seeding => title → article_id lookup mapping, if not test will fail
+    - add new route to app.js
+    - update endpoints.json
+    - pass all test
+    - push and pull

--- a/README.md
+++ b/README.md
@@ -105,3 +105,18 @@ node query.js
     - update endpoints.json
     - pass all test
     - push and pull
+
+# 4 GET /api/articles
+
+    - new branch
+    - get all articles sorted by date in desc
+    - no body property present on any of the article objects
+    - happy path test : return author,title,article_id, topic,created_at(timestmap number),votes,article_img_url, comment_count(comments table)
+    - superytest >> async/await
+    - require("jest-sorted");
+    - comment_count can't use js, need to make use of queries to the database => no 400/404 as not query str
+    - *no body
+    - tests : 200, 200 with corrected order, 200 with object no body
+    - using previous model and conttollers
+    - client -> controller -> model(sql) -> db.query(quesrtStr) send to PostgreSQL -> SQL query get data + count comments + sortby -> result.rows -> go back to controller > client
+    - seeding => title → article_id lookup mapping, if not test will fail

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -5,6 +5,7 @@ const db = require("../db/connection.js");
 const seed = require("../db/seeds/seed.js");
 const data = require("../db/data/test-data");
 const articles = require("../db/data/test-data/articles.js");
+require("jest-sorted");
 
 beforeEach(() => {
   jest.spyOn(Date, "now").mockImplementation(() => 1594329060000);
@@ -58,7 +59,7 @@ describe("2. GET /api/topics", () => {
   });
 });
 describe("3. GET /api/articles/:article_id", () => {
-  test("3a. 200: Responds with an object with all articles properties by article_id", () => {
+  /*  test("3a. 200: Responds with an object with all articles properties by article_id", () => {
     return request(app)
       .get("/api/articles/1")
       .expect(200)
@@ -76,7 +77,7 @@ describe("3. GET /api/articles/:article_id", () => {
           })
         );
       });
-  });
+  }); */ //<== similar to test 3b commented by Langa
   test("3b. 200: Responds with an object with all articles properties by article_id=1", () => {
     return request(app)
       .get("/api/articles/1")
@@ -114,6 +115,53 @@ describe("3. GET /api/articles/:article_id", () => {
       .expect(404)
       .then(({ body }) => {
         expect(body.msg).toBe("404 Not Found");
+      });
+  });
+});
+describe("4. Get /api/articles", () => {
+  test("4a. 200: Respond with array of article object without body and all required keys ", () => {
+    return request(app)
+      .get("/api/articles")
+      .expect(200)
+      .then((res) => {
+        const { articles } = res.body;
+        expect(Array.isArray(articles)).toBe(true);
+        articles.forEach((article) => {
+          expect(article).toEqual(
+            expect.objectContaining({
+              author: expect.any(String),
+              title: expect.any(String),
+              article_id: expect.any(Number),
+              topic: expect.any(String),
+              created_at: expect.any(String),
+              votes: expect.any(Number),
+              article_img_url: expect.any(String),
+              comment_count: expect.any(Number),
+            })
+          );
+          expect(article).not.toHaveProperty("body");
+        });
+      });
+  });
+  test("4b. 200: Respond with articles sorted by created_at in descending order", () => {
+    return request(app)
+      .get("/api/articles")
+      .expect(200)
+      .then((res) => {
+        const { articles } = res.body;
+        expect(articles).toBeSortedBy("created_at", { descending: true });
+      });
+  });
+  test("4c. 200: each article's comment_count matches expected total from test data", () => {
+    return request(app)
+      .get("/api/articles")
+      .expect(200)
+      .then((res) => {
+        const { articles } = res.body;
+        const articleWithComments = articles.find(
+          (article) => article.article_id === 3
+        );
+        expect(articleWithComments.comment_count).toBe(2);
       });
   });
 });

--- a/app.js
+++ b/app.js
@@ -8,11 +8,15 @@ app.use(express.json());
 //routes
 const { getApi } = require("./controllers/api.controller");
 const { getTopics } = require("./controllers/topics.controller");
-const { getArticleById } = require("./controllers/articles.controller");
+const {
+  getArticleById,
+  getAllArticles,
+} = require("./controllers/articles.controller");
 
 app.get("/api", getApi);
 app.get("/api/topics", getTopics);
 app.get("/api/articles/:article_id", getArticleById);
+app.get("/api/articles", getAllArticles);
 
 // 404 handler
 app.all("/*splat", (req, res) => {

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -1,10 +1,21 @@
-const { selectArticleById } = require("../models/articles.model");
+const {
+  selectArticleById,
+  selectAllArticles,
+} = require("../models/articles.model");
 
 exports.getArticleById = (req, res, next) => {
   const { article_id } = req.params;
   selectArticleById(article_id)
     .then((article) => {
       res.status(200).send({ article });
+    })
+    .catch(next);
+};
+
+exports.getAllArticles = async (req, res, next) => {
+  selectAllArticles()
+    .then((articles) => {
+      res.status(200).send({ articles });
     })
     .catch(next);
 };

--- a/endpoints.json
+++ b/endpoints.json
@@ -26,5 +26,23 @@
         }
       ]
     }
+  },
+  "GET /api/articles": {
+    "description": "serves an array of all articles, sorted by created_at descending. Each article includes the total comment_count and excludes the body.",
+    "queries": [],
+    "exampleResponse": {
+      "articles": [
+        {
+          "author": "butter_bridge",
+          "title": "Living in the shadow of a great man",
+          "article_id": 1,
+          "topic": "mitch",
+          "created_at": "2020-07-09T20:11:00.000Z",
+          "votes": 100,
+          "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+          "comment_count": 11
+        }
+      ]
+    }
   }
 }

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -1,4 +1,5 @@
 const db = require("../db/connection");
+const comments = require("../db/data/test-data/comments");
 
 exports.selectArticleById = (article_id) => {
   return db
@@ -15,4 +16,19 @@ exports.selectArticleById = (article_id) => {
       }
       return article;
     });
+};
+
+exports.selectAllArticles = async () => {
+  const queryStr = `SELECT articles.author, articles.title, articles.article_id,articles.topic, 
+  articles.created_at, 
+  articles.votes,
+  articles.article_img_url,
+  COUNT(comments.comment_id)::INT AS comment_count
+  FROM articles
+  LEFT JOIN comments
+  ON comments.article_id = articles.article_id
+  GROUP BY articles.article_id
+  ORDER BY articles.created_at DESC;`;
+  const result = await db.query(queryStr);
+  return result.rows;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
+        "jest-sorted": "^1.0.15",
         "pg": "^8.14.1",
         "pg-format": "^1.0.4",
         "supertest": "^7.1.0"
@@ -3191,6 +3192,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/jest-sorted": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.15.tgz",
+      "integrity": "sha512-bb5HzfyUqv22ToD63KRACZiwHVRVVj6/bl53VOODNQSzmTwKuTM0zYI73aByYulYVkugPmgGBXUTY8YLJYotKw==",
+      "license": "ISC"
     },
     "node_modules/jest-util": {
       "version": "27.5.1",
@@ -7442,6 +7449,11 @@
           "dev": true
         }
       }
+    },
+    "jest-sorted": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.15.tgz",
+      "integrity": "sha512-bb5HzfyUqv22ToD63KRACZiwHVRVVj6/bl53VOODNQSzmTwKuTM0zYI73aByYulYVkugPmgGBXUTY8YLJYotKw=="
     },
     "jest-util": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
+    "jest-sorted": "^1.0.15",
     "pg": "^8.14.1",
     "pg-format": "^1.0.4",
     "supertest": "^7.1.0"


### PR DESCRIPTION
# 4 GET /api/articles

    - new branch
    - get all articles sorted by date in desc
    - no body property present on any of the article objects
    - happy path test : return author,title,article_id, topic,created_at(timestmap number),votes,article_img_url, comment_count(comments table)
    - require("jest-sorted");
    - comment_count can't use js, need to make use of queries to the database => no 400/404 as not query str
    - no body
    - tests : 200, 200 with corrected order, 200 with object no body
    - using previous model and conttollers
    - client -> controller -> model(sql) -> db.query(quesrtStr) send to PostgreSQL -> SQL query get data + count comments + sortby -> result.rows -> go back to controller > client
    - seeding => title → article_id lookup mapping, if not test will fail
    - add new route to app.js
    - update endpoints.json
    - pass all test
    - push and pull